### PR TITLE
Fix analytics buttons display on smaller screens

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -33,6 +33,7 @@ p, .control-label {
 @media (max-width: 992px) {
   .mainform #optin .btn {
     display: block;
+    clear: both;
     border-radius: 4px;
     width: 200px;
   }

--- a/assets/app.css
+++ b/assets/app.css
@@ -29,6 +29,19 @@ p, .control-label {
   color: #666;
 }
 
+/* Responsive button fixes for analytics */
+@media (max-width: 992px) {
+  .mainform #optin .btn {
+    display: block;
+    border-radius: 4px;
+    width: 200px;
+  }
+
+  .mainform #optin .btn:nth-child(n+2) {
+    margin-top: 10px;
+  }
+}
+
 /* idcard control */
 @media (min-width: 768px) {
   .form-inline .form-control.idcard-letters {


### PR DESCRIPTION
Instead of this:

<img width="381" alt="screen shot 2016-04-19 at 8 18 07 pm" src="https://cloud.githubusercontent.com/assets/440015/14652393/07076ce4-066c-11e6-8be2-2af24e845754.png">

It will now look like this:

<img width="437" alt="screen shot 2016-04-19 at 8 25 46 pm" src="https://cloud.githubusercontent.com/assets/440015/14652624/055953e8-066d-11e6-9063-6512e60fa8a4.png">
